### PR TITLE
logic of of QR accesses selection  has been improved

### DIFF
--- a/src/repositories/QRAccess.repository.ts
+++ b/src/repositories/QRAccess.repository.ts
@@ -32,17 +32,18 @@ export class QRAccessRepository extends Repository<EQRAccess> {
     return await this.find();
   }
 
-  async getQrEntries(queryOptions: IQrFindOptions): Promise<IQRAccess[]> {
+  async getQrEntries(queryOptions: IQrFindOptions, allowedUsersIds?:string[]): Promise<IQRAccess[]> {
     const findOptions = createQrFindOptions(queryOptions);
-
     const { locks } = queryOptions;
-
-    const unfilteredResult = await this.find(findOptions);
-
+    const unfilteredResult = await this.find({where: findOptions.where});
     if (locks && locks.length > 0) {
-      return await this.filterQueryByLockIds(locks, unfilteredResult);
+      const filteredByLocksResults = await this.filterQueryByLockIds(locks, unfilteredResult);
+      return allowedUsersIds?  filteredByLocksResults.filter((qr) => {return allowedUsersIds.includes(qr.author)})
+      : filteredByLocksResults
+
     } else {
-      return unfilteredResult;
+      return  allowedUsersIds?  unfilteredResult.filter((qr) => {return allowedUsersIds.includes(qr.author)}):
+      unfilteredResult
     }
   }
 

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -9,8 +9,6 @@ import {
 import { buildUpdateEntity } from "@/middleware/entityCheckers/updateEntitiesMerger.middleware";
 import { checkUserUpdate } from "@/middleware/entityCheckers/userUpdateChecker.middleware";
 import { checkQuery } from "@/middleware/queryChecker.middleware";
-import { checkRole } from "@/middleware/roleChecker.middleware";
-import { ERole } from "@/types/roles";
 import { Router } from "express";
 
 export class UserRoute {
@@ -27,12 +25,6 @@ export class UserRoute {
     this.router.get(
       "/",
       checkAuth,
-      checkRole([
-        ERole.umanuAdmin,
-        ERole.organizationAdmin,
-        ERole.buildingAdmin,
-        ERole.tenantAdmin,
-      ]),
       checkQuery<IUserFindOptions>("user"),
       checkOrganizationAccess,
       checkBuildingAccess,

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -26,6 +26,8 @@ export class UserService {
       case ERole.tenantAdmin:
         queryOptions.tenantId = user.tenantId;
         break;
+      case ERole.user: 
+        return [user]
     }
     return await this.userRepo.getUsersQuery(queryOptions);
   }


### PR DESCRIPTION
logic of of QR accesses selection  has been improved

1) From now on response includes qr-accesses created by users "visible" to current user with locks allowed for current user (or specified in query, if current user has all respective rights)

2) Seeder has been improved to match current DB structure and logic 